### PR TITLE
Add support for linux host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ ext {
     external.libimobiledevice.jnipath = file("${external.libimobiledevice.root}/build/macos")
 }
 for (target in [[name: 'macos', outputs: ["${external.libimobiledevice.root}/build/macos/libimobiledevice.dylib"]],
-                [name: 'windows', outputs: ["${external.libimobiledevice.root}/build/windows/x86_64-w64-mingw32/libimobiledevice.dll"]]]) {
+                [name: 'windows', outputs: ["${external.libimobiledevice.root}/build/windows/x86_64-w64-mingw32/libimobiledevice.dll"]],
+                [name: 'linux', outputs: ["${external.libimobiledevice.root}/build/linux/libimobiledevice.so"]]]) {
     external.libimobiledevice[target.name] = target.outputs.collect { file(it) }
 
     task("prebuild_libimobiledevice_${target.name}", type: Exec) {
@@ -86,6 +87,7 @@ for (target in [[name: 'ios', outputs: ["${external.natj.root}/natj-ios/build/xc
                                         "${external.natj.root}/natj-ios/build/xcode/Release-iphonesimulator/libnatj.a"]],
                 [name: 'mac', outputs: ["${external.natj.root}/natj-mac/build/xcode/Release/libnatj.dylib"]],
                 [name: 'win', outputs: ["${external.natj.root}/natj-win/build/Release-Win64/natj.dll"]],
+                [name: 'linux', outputs: ["${external.natj.root}/natj-linux/build/Release/libnatj.so"]],
                 [name: 'api', outputs: [external.natj.jar.absolutePath], task: 'jar']]) {
     external.natj[target.name] = target.outputs.collect { file(it) }
 


### PR DESCRIPTION
The pr enables first support of linux as a host. IntelliJ plugin works fine. moeLaunch also works. ~NatJGen does not work yet.~ (Wont be fixed)
For cross compiling I decided to go with gcc. I tried with clang, but that didn't really worked that well for me. 

This fixes https://github.com/multi-os-engine/multi-os-engine/issues/34
Maybe fixes https://github.com/multi-os-engine/multi-os-engine/issues/132

Related pr's:
https://github.com/multi-os-engine/moe-prebuilts/pull/2
https://github.com/multi-os-engine/moe-natj/pull/7
https://github.com/multi-os-engine/moe-binding-libimobiledevice/pull/2
https://github.com/multi-os-engine/moe-ios-device-launcher/pull/2
https://github.com/multi-os-engine/moe-plugin-gradle/pull/16
https://github.com/multi-os-engine/moe-sdk-publisher/pull/5
https://github.com/multi-os-engine/moe-tools-common/pull/3